### PR TITLE
Fix logic to correctly display previous month as December

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,11 +100,13 @@ func printSummary(client *slack.Client, shifts map[string]int) error {
 		})
 	}
 
+	oneMonth, _ := time.ParseDuration("24h")
+	oneMonth = oneMonth * 31
 	if _, _, err := client.PostMessage(
 		"#noise-shift-count",
 		slack.MsgOptionAsUser(true),
 		slack.MsgOptionText(
-			fmt.Sprintf("Area oncall shift counts (%v of %v to %v of %v)", START_DATE, time.Now().Month()-1, START_DATE-1, time.Now().Month()),
+			fmt.Sprintf("Area oncall shift counts (%v of %v to %v of %v)", START_DATE, time.Now().Add((-oneMonth)), START_DATE-1, time.Now().Month()),
 			false,
 		),
 		slack.MsgOptionAttachments(attachment),


### PR DESCRIPTION
In January the previous month currently shows as `%!Month(0)` this fixes it to actually roll back to the previous December.