### PR TITLE
Fix slack message format

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func printSummary(client *slack.Client, shifts map[string]int) error {
 		"#noise-shift-count",
 		slack.MsgOptionAsUser(true),
 		slack.MsgOptionText(
-			fmt.Sprintf("Area oncall shift counts (%v of %v to %v of %v)", START_DATE, time.Now().Add((-oneMonth)), START_DATE-1, time.Now().Month()),
+			fmt.Sprintf("Area oncall shift counts (%v of %v to %v of %v)", START_DATE, time.Now().Add((-oneMonth)).Month(), START_DATE-1, time.Now().Month()),
 			false,
 		),
 		slack.MsgOptionAttachments(attachment),


### PR DESCRIPTION
This is the latest message we got on slack:

```
Area oncall shift counts (20 of 2022-02-17 06:02:10.377403182 +0000 UTC m=-2678273.739076029 to 19 of March)
```

Goal of this PR is to make it like so:

```
Area oncall shift counts (20 of February to 19 of March)
```