### PR TITLE
Fixes run as non-root

### DIFF
--- a/k8s/cronjob.yaml
+++ b/k8s/cronjob.yaml
@@ -24,6 +24,9 @@ spec:
                 drop:
                 - ALL
               privileged: false
+              runAsGroup: 1000
+              runAsNonRoot: true
+              runAsUser: 1000
               seccompProfile:
                 type: RuntimeDefault
             env:


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/29591

Fixes:

```
  Warning  Failed     72s (x8 over 2m39s)  kubelet            Error: container has runAsNonRoot and image will run as root (pod: "joe-manual-run-001-prm9r_opsgenie-shift-reporter(b3409115-de78-45bb-bdfe-a3d41827c3c7)", container: opsgenie-shift-reporter)
```